### PR TITLE
TensorFlow base predictors

### DIFF
--- a/ei.py
+++ b/ei.py
@@ -11,6 +11,7 @@ from sklearn.utils._testing import ignore_warnings
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.model_selection import StratifiedKFold
 from joblib import Parallel, delayed
+from joblib.externals.loky import set_loky_pickler
 from sklearn.calibration import CalibratedClassifierCV
 import warnings
 from utils import scores, set_seed, random_integers, sample, retrieve_X_y, append_modality, metric_threshold_dataframes
@@ -83,6 +84,7 @@ class EnsembleIntegration:
                  project_name="project"):
 
         set_seed(random_state)
+        set_loky_pickler('pickle')
 
         self.base_predictors = base_predictors
         if meta_models is not None:

--- a/ei.py
+++ b/ei.py
@@ -282,7 +282,8 @@ class EnsembleIntegration:
         fold_id, (train_index, test_index) = fold_params
         sample_id, sample_random_state = sample_state
 
-        # model = CalibratedClassifierCV(model, n_jobs=1, ensemble=True)  # calibrate classifiers
+        if model.__class__.__name__ is not "KerasClassifier":
+            model = CalibratedClassifierCV(model, n_jobs=1, ensemble=True)  # calibrate classifiers
 
         X_train, X_test = X[train_index], X[test_index]
         y_train, y_test = y[train_index], y[test_index]

--- a/ei.py
+++ b/ei.py
@@ -11,6 +11,7 @@ from sklearn.utils._testing import ignore_warnings
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.model_selection import StratifiedKFold
 from joblib import Parallel, delayed
+from tensorflow.keras.backend import clear_session
 from joblib.externals.loky import set_loky_pickler
 from sklearn.calibration import CalibratedClassifierCV
 import warnings
@@ -296,6 +297,9 @@ class EnsembleIntegration:
 
         if model.__class__.__name__ != "KerasClassifier":  # not working for KerasClassifier for some reason
             model = CalibratedClassifierCV(model, n_jobs=1, ensemble=True)  # calibrate classifiers
+
+        if model.__class__.__name__ == "KerasClassifier":  # clear any previous TensorFlow sessions
+            clear_session()
 
         X_train, X_test = X[train_index], X[test_index]
         y_train, y_test = y[train_index], y[test_index]

--- a/ei.py
+++ b/ei.py
@@ -282,7 +282,7 @@ class EnsembleIntegration:
         fold_id, (train_index, test_index) = fold_params
         sample_id, sample_random_state = sample_state
 
-        model = CalibratedClassifierCV(model, n_jobs=1, ensemble=True)  # calibrate classifiers
+        # model = CalibratedClassifierCV(model, n_jobs=1, ensemble=True)  # calibrate classifiers
 
         X_train, X_test = X[train_index], X[test_index]
         y_train, y_test = y[train_index], y[test_index]

--- a/ei.py
+++ b/ei.py
@@ -84,6 +84,7 @@ class EnsembleIntegration:
                  project_name="project"):
 
         set_seed(random_state)
+        # set_loky_pickler("dill")  # not working. Attempt to get Parallel working with KerasClassifier()
 
         self.base_predictors = base_predictors
         if meta_models is not None:
@@ -281,7 +282,7 @@ class EnsembleIntegration:
         fold_id, (train_index, test_index) = fold_params
         sample_id, sample_random_state = sample_state
 
-        model = CalibratedClassifierCV(model, ensemble=True)  # calibrate classifiers
+        #model = CalibratedClassifierCV(model, ensemble=True)  # calibrate classifiers
 
         X_train, X_test = X[train_index], X[test_index]
         y_train, y_test = y[train_index], y[test_index]

--- a/ei.py
+++ b/ei.py
@@ -21,7 +21,7 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)
 def create_base_summary(meta_test_dataframe):
     labels = pd.concat([df["labels"] for df in meta_test_dataframe])
     meta_test_averaged_samples = pd.concat(
-        [df.drop(columns=["labels"], level=0).groupby(level=(0, 1), axis=1).mean() for df in self.meta_test_data])
+        [df.drop(columns=["labels"], level=0).groupby(level=(0, 1), axis=1).mean() for df in meta_test_dataframe])
     meta_test_averaged_samples["labels"] = labels
     return metric_threshold_dataframes(meta_test_averaged_samples)
 

--- a/ei.py
+++ b/ei.py
@@ -84,7 +84,7 @@ class EnsembleIntegration:
                  project_name="project"):
 
         set_seed(random_state)
-        set_loky_pickler("dill")  # not working. Attempt to get Parallel working with Keras Classifier
+        # set_loky_pickler("dill")  # not working. Attempt to get Parallel working with KerasClassifier()
 
         self.base_predictors = base_predictors
         if meta_models is not None:
@@ -180,9 +180,6 @@ class EnsembleIntegration:
 
         if modality is not None:
             print(f"\nWorking on {modality} data...")
-
-            # self.base_predictors = update_keys(dictionary=self.base_predictors,
-            #                                    string=modality)  # include modality in model name
 
         if (self.meta_training_data or self.meta_test_data) is None:
             self.meta_training_data = self.train_base_inner(X, y, modality)
@@ -285,7 +282,7 @@ class EnsembleIntegration:
         fold_id, (train_index, test_index) = fold_params
         sample_id, sample_random_state = sample_state
 
-        #model = CalibratedClassifierCV(model, ensemble=True)  # calibrate classifiers
+        model = CalibratedClassifierCV(model, ensemble=True)  # calibrate classifiers
 
         X_train, X_test = X[train_index], X[test_index]
         y_train, y_test = y[train_index], y[test_index]

--- a/ei.py
+++ b/ei.py
@@ -282,7 +282,7 @@ class EnsembleIntegration:
         fold_id, (train_index, test_index) = fold_params
         sample_id, sample_random_state = sample_state
 
-        #model = CalibratedClassifierCV(model, ensemble=True)  # calibrate classifiers
+        model = CalibratedClassifierCV(model, n_jobs=1, ensemble=True)  # calibrate classifiers
 
         X_train, X_test = X[train_index], X[test_index]
         y_train, y_test = y[train_index], y[test_index]

--- a/ei.py
+++ b/ei.py
@@ -84,7 +84,7 @@ class EnsembleIntegration:
                  project_name="project"):
 
         set_seed(random_state)
-        set_loky_pickler("dill")
+        # set_loky_pickler("dill")  # not working. Attempt to get Parallel working with Keras Classifier
 
         self.base_predictors = base_predictors
         if meta_models is not None:

--- a/ei.py
+++ b/ei.py
@@ -79,6 +79,7 @@ class EnsembleIntegration:
                  sampling_aggregation="mean",
                  n_jobs=-1,
                  random_state=None,
+                 parallel_backend="loky",
                  project_name="project"):
 
         set_seed(random_state)
@@ -94,6 +95,7 @@ class EnsembleIntegration:
         self.n_jobs = n_jobs
         self.random_state = random_state
         self.project_name = project_name
+        self.parallel_backend = parallel_backend
 
         self.trained_meta_models = {}
         self.trained_base_predictors = {}
@@ -219,7 +221,7 @@ class EnsembleIntegration:
         # dictionaries for meta train/test data for each outer fold
         meta_training_data = []
         # define joblib Parallel function
-        parallel = Parallel(n_jobs=self.n_jobs, verbose=10, backend="threading")
+        parallel = Parallel(n_jobs=self.n_jobs, verbose=10, backend=self.parallel_backend)
         for outer_fold_id, (train_index_outer, test_index_outer) in enumerate(self.cv_outer.split(X, y)):
             print("\nGenerating meta-training data for outer fold {outer_fold_id:}...".format(
                 outer_fold_id=outer_fold_id))
@@ -259,7 +261,7 @@ class EnsembleIntegration:
         """
 
         # define joblib Parallel function
-        parallel = Parallel(n_jobs=self.n_jobs, verbose=10, backend="threading")
+        parallel = Parallel(n_jobs=self.n_jobs, verbose=10, backend=self.parallel_backend)
 
         print("\nTraining base predictors on outer training sets...")
 

--- a/ei.py
+++ b/ei.py
@@ -285,7 +285,7 @@ class EnsembleIntegration:
         fold_id, (train_index, test_index) = fold_params
         sample_id, sample_random_state = sample_state
 
-        model = CalibratedClassifierCV(model, ensemble=True)  # calibrate classifiers
+        #model = CalibratedClassifierCV(model, ensemble=True)  # calibrate classifiers
 
         X_train, X_test = X[train_index], X[test_index]
         y_train, y_test = y[train_index], y[test_index]

--- a/ei.py
+++ b/ei.py
@@ -84,7 +84,6 @@ class EnsembleIntegration:
                  project_name="project"):
 
         set_seed(random_state)
-        # set_loky_pickler("dill")  # not working. Attempt to get Parallel working with KerasClassifier()
 
         self.base_predictors = base_predictors
         if meta_models is not None:

--- a/ei.py
+++ b/ei.py
@@ -219,7 +219,7 @@ class EnsembleIntegration:
         # dictionaries for meta train/test data for each outer fold
         meta_training_data = []
         # define joblib Parallel function
-        parallel = Parallel(n_jobs=self.n_jobs, verbose=10)
+        parallel = Parallel(n_jobs=self.n_jobs, verbose=10, backend="threading")
         for outer_fold_id, (train_index_outer, test_index_outer) in enumerate(self.cv_outer.split(X, y)):
             print("\nGenerating meta-training data for outer fold {outer_fold_id:}...".format(
                 outer_fold_id=outer_fold_id))
@@ -259,7 +259,7 @@ class EnsembleIntegration:
         """
 
         # define joblib Parallel function
-        parallel = Parallel(n_jobs=self.n_jobs, verbose=10)
+        parallel = Parallel(n_jobs=self.n_jobs, verbose=10, backend="threading")
 
         print("\nTraining base predictors on outer training sets...")
 
@@ -280,12 +280,16 @@ class EnsembleIntegration:
         model_name, model = model_params
         fold_id, (train_index, test_index) = fold_params
         sample_id, sample_random_state = sample_state
+
         model = CalibratedClassifierCV(model, ensemble=True)  # calibrate classifiers
+
         X_train, X_test = X[train_index], X[test_index]
         y_train, y_test = y[train_index], y[test_index]
         X_sample, y_sample = sample(X_train, y_train, strategy=self.sampling_strategy, random_state=sample_random_state)
         model.fit(X_sample, y_sample)
+
         y_pred = model.predict_proba(X_test)[:, 1]
+
         metrics = scores(y_test, y_pred)
 
         results_dict = {"model_name": model_name,

--- a/ei.py
+++ b/ei.py
@@ -84,7 +84,7 @@ class EnsembleIntegration:
                  project_name="project"):
 
         set_seed(random_state)
-        # set_loky_pickler("dill")  # not working. Attempt to get Parallel working with Keras Classifier
+        set_loky_pickler("dill")  # not working. Attempt to get Parallel working with Keras Classifier
 
         self.base_predictors = base_predictors
         if meta_models is not None:

--- a/ei.py
+++ b/ei.py
@@ -84,7 +84,7 @@ class EnsembleIntegration:
                  project_name="project"):
 
         set_seed(random_state)
-        set_loky_pickler('pickle')
+        set_loky_pickler('dill')
 
         self.base_predictors = base_predictors
         if meta_models is not None:

--- a/ei.py
+++ b/ei.py
@@ -84,7 +84,7 @@ class EnsembleIntegration:
                  project_name="project"):
 
         set_seed(random_state)
-        #set_loky_pickler("cloudpickle")
+        set_loky_pickler(pickle)
 
         self.base_predictors = base_predictors
         if meta_models is not None:

--- a/ei.py
+++ b/ei.py
@@ -6,7 +6,7 @@ Ensemble Integration
 
 import pandas as pd
 import numpy as np
-import pickle
+import dill as pickle
 from sklearn.utils._testing import ignore_warnings
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.model_selection import StratifiedKFold
@@ -84,7 +84,7 @@ class EnsembleIntegration:
                  project_name="project"):
 
         set_seed(random_state)
-        set_loky_pickler("cloudpickle")
+        #set_loky_pickler("cloudpickle")
 
         self.base_predictors = base_predictors
         if meta_models is not None:

--- a/ei.py
+++ b/ei.py
@@ -282,7 +282,7 @@ class EnsembleIntegration:
         fold_id, (train_index, test_index) = fold_params
         sample_id, sample_random_state = sample_state
 
-        if model.__class__.__name__ != "KerasClassifier":
+        if model.__class__.__name__ != "KerasClassifier":  # not working for KerasClassifier for some reason
             model = CalibratedClassifierCV(model, n_jobs=1, ensemble=True)  # calibrate classifiers
 
         X_train, X_test = X[train_index], X[test_index]

--- a/ei.py
+++ b/ei.py
@@ -282,7 +282,7 @@ class EnsembleIntegration:
         fold_id, (train_index, test_index) = fold_params
         sample_id, sample_random_state = sample_state
 
-        if model.__class__.__name__ is not "KerasClassifier":
+        if model.__class__.__name__ != "KerasClassifier":
             model = CalibratedClassifierCV(model, n_jobs=1, ensemble=True)  # calibrate classifiers
 
         X_train, X_test = X[train_index], X[test_index]

--- a/ei.py
+++ b/ei.py
@@ -84,7 +84,7 @@ class EnsembleIntegration:
                  project_name="project"):
 
         set_seed(random_state)
-        set_loky_pickler(pickle)
+        set_loky_pickler("dill")
 
         self.base_predictors = base_predictors
         if meta_models is not None:

--- a/ei.py
+++ b/ei.py
@@ -80,7 +80,7 @@ class EnsembleIntegration:
                  sampling_aggregation="mean",
                  n_jobs=-1,
                  random_state=None,
-                 parallel_backend="loky",
+                 parallel_backend="threading",
                  project_name="project"):
 
         set_seed(random_state)

--- a/ei.py
+++ b/ei.py
@@ -84,7 +84,7 @@ class EnsembleIntegration:
                  project_name="project"):
 
         set_seed(random_state)
-        set_loky_pickler('dill')
+        set_loky_pickler("cloudpickle")
 
         self.base_predictors = base_predictors
         if meta_models is not None:

--- a/utils.py
+++ b/utils.py
@@ -139,7 +139,7 @@ def retrieve_X_y(labelled_data):
     return X, y
 
 
-# def update_keys(dictionary, string):
+# def update_keys(dictionary, string):  #  not needed since use of MultiIndexing
 #     return {f"{k}_" + string: v for k, v in dictionary.items()}
 
 

--- a/utils.py
+++ b/utils.py
@@ -2,9 +2,13 @@ import pandas as pd
 import numpy as np
 import random
 from sklearn.metrics import accuracy_score, roc_curve, roc_auc_score, precision_recall_curve, matthews_corrcoef
+from tensorflow.keras.wrappers.scikit_learn import KerasClassifier
 from imblearn.under_sampling import RandomUnderSampler
 from imblearn.over_sampling import RandomOverSampler
 
+def tf_classifier_to_sk(tf_model, epochs=100, batch_size=500, verbose=0):
+    build_fn = lambda: tf_model
+    return KerasClassifier(build_fn, epochs=epochs, batch_size=batch_size, verbose=verbose)
 
 def score_threshold_vectors(df, labels):
     fmax = []


### PR DESCRIPTION
Base predictors can now be TensorFlow models with the use of the function tf_classifier_to_sk()